### PR TITLE
Add package-initialize to .emacs

### DIFF
--- a/.emacs.el
+++ b/.emacs.el
@@ -49,6 +49,9 @@
 (when (< emacs-major-version 24)
   ;; For important compatibility libraries like cl-lib
   (add-to-list 'package-archives '("gnu" . "http://elpa.gnu.org/packages/")))
+
+;;see https://emacs.stackexchange.com/a/48943/8887 for more details
+(package-initialize)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Add package-initialize to .emacs, so that installed packages can be properly initialized and loaded. Fix #12  

This is related to the following Emacs StackExchange issue: 

Why can't Emacs find counsel and swiper, even though they (and Ivy) seem installed, and Ivy working?
https://emacs.stackexchange.com/questions/48941/why-cant-emacs-find-counsel-and-swiper-even-though-they-and-ivy-seem-install